### PR TITLE
Document Drive init error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 - Commit the contents of the `docs` directory along with your changes.
 - Bump the version in `package.json` after each change.
 - When the portfolio file structure changes, bump the file version and add a conversion function with a corresponding unit test to upgrade older files.
+- Keep the real Google API key and client ID as defined in environment variables in the build output under `docs`.
+- Never explicitly set `VITE_GOOGLE_API_KEY` or `VITE_GOOGLE_CLIENT_ID` if they are already defined in the environment.
+- Wrap `gapi.client.init` in a try/catch; on discovery failure, display an error and disable Google Drive operations.
 
 Functionality Guidelines:
 Tables are sortable – Column headers toggle ascending/descending order with ▲/▼ indicators.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-CNXKIwkp.js"></script>
+    <script type="module" crossorigin src="./assets/index-cV-uwaKN.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.40",
+  "version": "1.0.43",
   "description": "",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- note that Google Drive init must be wrapped in a try/catch and fail closed on discovery errors
- bump package version to 1.0.43 and rebuild docs with real env credentials

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a385d2b25483259a01097a2c0f0e0a