### PR TITLE
Rebuild docs with real Drive credentials and clarify build steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - When the portfolio file structure changes, bump the file version and add a conversion function with a corresponding unit test to upgrade older files.
 - Keep the real Google API key and client ID as defined in environment variables in the build output under `docs`.
 - Never explicitly set `VITE_GOOGLE_API_KEY` or `VITE_GOOGLE_CLIENT_ID` if they are already defined in the environment.
+- When building, rely on those existing environment variables; run `npm run build` without prefixing alternate values so the real credentials are embedded in `docs`.
 - Wrap `gapi.client.init` in a try/catch; on discovery failure, display an error and disable Google Drive operations.
 
 Functionality Guidelines:

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-cV-uwaKN.js"></script>
+    <script type="module" crossorigin src="./assets/index-7cNpzMAS.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "test2",
-  "version": "1.0.39",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "test2",
-      "version": "1.0.39",
+      "version": "1.0.45",
       "license": "ISC",
       "dependencies": {
         "react": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.43",
+  "version": "1.0.45",
   "description": "",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Clarify build instructions to rely on existing Google API environment variables.
- Bump package version to 1.0.45.
- Rebuild docs so compiled assets embed the real Google Drive credentials.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a38d02492883258237d0f7b46039e6