### PR TITLE
Improve Drive file handling and validation messages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-vaWEo6_N.js"></script>
+    <script type="module" crossorigin src="./assets/index-DYwzEHSO.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "test2",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "test2",
-      "version": "1.0.46",
+    "version": "1.0.47",
       "license": "ISC",
       "dependencies": {
         "react": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/src/drive.js
+++ b/src/drive.js
@@ -39,18 +39,26 @@ function ensureToken() {
 
 export async function openDriveFile() {
   if (!driveReady || !gapi?.client?.getToken || !tokenClient) return;
-  await ensureToken();
+  try {
+    await ensureToken();
+  } catch (err) {
+    throw new Error("Failed to authorize with Google Drive");
+  }
   const defaultName = localStorage.getItem(DRIVE_FILENAME_KEY) || "portfolio.enc";
   const name = prompt("Enter Google Drive filename", defaultName);
   if (!name) return;
   localStorage.setItem(DRIVE_FILENAME_KEY, name);
-  const res = await gapi.client.drive.files.list({
-    q: `name='${name.replace(/['\\]/g, "\\$&")}' and trashed=false`,
-    pageSize: 1,
-    fields: "files(id)",
-  });
-  const file = res?.result?.files?.[0];
-  return file?.id;
+  try {
+    const res = await gapi.client.drive.files.list({
+      q: `name='${name.replace(/['\\]/g, "\\$&")}' and trashed=false`,
+      pageSize: 1,
+      fields: "files(id)",
+    });
+    const file = res?.result?.files?.[0];
+    return file?.id;
+  } catch (err) {
+    throw new Error("Failed to search Google Drive for file");
+  }
 }
 
 export async function readDrivePortfolioFile(fileId, password) {

--- a/src/hooks/usePortfolioFile.js
+++ b/src/hooks/usePortfolioFile.js
@@ -87,6 +87,10 @@ export default function usePortfolioFile({
   async function handleOpenDrive() {
     try {
       const id = await openDriveFile();
+      if (!id) {
+        setError("Select a Google Drive file.");
+        return;
+      }
       setDriveFileId(id);
       setFileHandle(null);
       setStep("password");
@@ -135,7 +139,8 @@ export default function usePortfolioFile({
   }
 
   async function handleLoad() {
-    if ((!fileHandle && !driveFileId) || !password) return setError("Pick a file and enter password first.");
+    if (!fileHandle && !driveFileId) return setError("Select a file first.");
+    if (!password) return setError("Enter a password first.");
     setLoading(true);
     setError(null);
     try {
@@ -206,7 +211,8 @@ export default function usePortfolioFile({
   }
 
   async function handleSave() {
-    if ((!fileHandle && !driveFileId) || !password) return setError("Pick a file and enter password first.");
+    if (!fileHandle && !driveFileId) return setError("Select a file first.");
+    if (!password) return setError("Enter a password first.");
     await withLoading(async () => {
       const data = buildPortfolioData();
       if (driveFileId) {


### PR DESCRIPTION
## Summary
- Guard Google Drive file selection against authorization and listing errors
- Guide users to select a Drive file and enter a password separately
- Bump version to 1.0.47

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a44b9ffc9083259f646ae428b792f0