### PR TITLE
Handle Google Drive token redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-DYwzEHSO.js"></script>
+    <script type="module" crossorigin src="./assets/index-nlfiwP-D.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/src/drive.js
+++ b/src/drive.js
@@ -14,10 +14,25 @@ export function initDrive({ apiKey, clientId }) {
           apiKey,
           discoveryDocs: ["https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"],
         });
+        const url = new URL(window.location.href);
+        const hashParams = new URLSearchParams(url.hash.replace(/^#/, ""));
+        const searchParams = url.searchParams;
+        const accessToken = hashParams.get("access_token") || searchParams.get("access_token");
+        const code = searchParams.get("code") || hashParams.get("code");
+        if (accessToken || code) {
+          gapi.client.setToken(
+            accessToken ? { access_token: accessToken } : { code }
+          );
+          url.hash = "";
+          url.search = "";
+          window.history.replaceState({}, "", url.toString());
+        }
         tokenClient = google.accounts.oauth2.initTokenClient({
           client_id: clientId,
           scope: "https://www.googleapis.com/auth/drive.file",
           callback: () => {},
+          ux_mode: "redirect",
+          redirect_uri: window.location.origin,
         });
         driveReady = true;
       } catch (err) {
@@ -31,6 +46,10 @@ export function initDrive({ apiKey, clientId }) {
 }
 
 function ensureToken() {
+  const token = gapi.client.getToken();
+  if (token?.access_token) {
+    return Promise.resolve();
+  }
   return new Promise((resolve) => {
     tokenClient.callback = () => resolve();
     tokenClient.requestAccessToken();


### PR DESCRIPTION
## Summary
- support OAuth redirect by parsing access tokens in URL and cleaning the location
- initialize token client in redirect mode with redirect URI
- avoid requesting a new access token when one already exists
- rebuild production assets with embedded Google API credentials

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a456a9fa148325afbb174dad0ef952