### PR TITLE
feat: create missing Drive files

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-CSXnzKcy.js"></script>
+    <script type="module" crossorigin src="./assets/index-BWxP8L_7.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/usePortfolioFile.js
+++ b/src/hooks/usePortfolioFile.js
@@ -86,9 +86,9 @@ export default function usePortfolioFile({
 
   async function handleOpenDrive() {
     try {
-      const id = await openDriveFile();
+      const id = await openDriveFile(password);
       if (!id) {
-        setError("Select a Google Drive file.");
+        setError("Select or create a Google Drive file.");
         return;
       }
       setDriveFileId(id);


### PR DESCRIPTION
## Summary
- allow creating a new Google Drive portfolio when search finds nothing
- handle new Drive flow in portfolio hook
- cover Drive creation and cancellation paths with unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4a334c5b483259deee45d6679c40f