### PR TITLE
feat: embed build timestamp

### DIFF
--- a/docs/assets/index-DhzhkHtB.js
+++ b/docs/assets/index-DhzhkHtB.js
@@ -2253,7 +2253,7 @@ function useLiabilityManager({ assets, liabilities, liabilityTypes, setAssetsAnd
     cancelDeleteLiability
   };
 }
-const version = "1.0.51";
+const version = "1.0.52";
 const pkg = {
   version
 };
@@ -2274,6 +2274,19 @@ function App() {
   const driveApiKey = "AIzaSyD9IhFBHBHEs729edMO7LsoKZFlTfsnv5U";
   const driveClientId = "967365398072-sj6mjo1r3pdg18frmdl5aoafnvbbsfob.apps.googleusercontent.com";
   const driveReady2 = driveClientId;
+  const builtAgo = reactExports.useMemo(() => {
+    const ts = "2025-08-19T16:40:16.681Z";
+    const diff = Date.now() - new Date(ts).getTime();
+    const rtf = new Intl.RelativeTimeFormat(void 0, { numeric: "auto" });
+    const seconds = Math.floor(diff / 1e3);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    if (days > 0) return rtf.format(-days, "day");
+    if (hours > 0) return rtf.format(-hours, "hour");
+    if (minutes > 0) return rtf.format(-minutes, "minute");
+    return rtf.format(-seconds, "second");
+  }, []);
   const {
     snapshots,
     setSnapshots,
@@ -2371,7 +2384,11 @@ function App() {
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: handleOpenExisting, className: "h-12 px-6 rounded-lg bg-blue-600 hover:bg-blue-500", children: "Open existing file" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: handleCreateNew, className: "h-12 px-6 rounded-lg bg-blue-600 hover:bg-blue-500", children: "Create new file" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: handleOpenDrive, className: "h-12 px-6 rounded-lg bg-blue-600 hover:bg-blue-500", children: "Open from Google Drive" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: handleOpenSample, className: "text-sm text-blue-400 underline", children: "Open sample portfolio" })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: handleOpenSample, className: "text-sm text-blue-400 underline", children: "Open sample portfolio" }),
+      builtAgo && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "text-sm text-zinc-400", children: [
+        "Built ",
+        builtAgo
+      ] })
     ] }),
     step === "password" && /* @__PURE__ */ jsxRuntimeExports.jsxs("form", { onSubmit: (e) => {
       e.preventDefault();

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-BWxP8L_7.js"></script>
+    <script type="module" crossorigin src="./assets/index-DhzhkHtB.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,6 +10,9 @@ if (missing.length) {
   process.exit(1);
 }
 
+// Embed build timestamp so the app can display when it was built
+process.env.VITE_BUILD_TIME = new Date().toISOString();
+
 // Run vite build to output to docs
 execSync('vite build', { stdio: 'inherit' });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,20 @@ export default function App() {
   const driveApiKey = import.meta.env.VITE_GOOGLE_API_KEY;
   const driveClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
   const driveReady = driveApiKey && driveClientId;
+  const builtAgo = useMemo(() => {
+    const ts = import.meta.env.VITE_BUILD_TIME;
+    if (!ts) return null;
+    const diff = Date.now() - new Date(ts).getTime();
+    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    if (days > 0) return rtf.format(-days, 'day');
+    if (hours > 0) return rtf.format(-hours, 'hour');
+    if (minutes > 0) return rtf.format(-minutes, 'minute');
+    return rtf.format(-seconds, 'second');
+  }, []);
 
   const {
     snapshots,
@@ -165,6 +179,9 @@ export default function App() {
             <button onClick={handleOpenDrive} className="h-12 px-6 rounded-lg bg-blue-600 hover:bg-blue-500">Open from Google Drive</button>
           )}
           <button onClick={handleOpenSample} className="text-sm text-blue-400 underline">Open sample portfolio</button>
+          {builtAgo && (
+            <div className="text-sm text-zinc-400">Built {builtAgo}</div>
+          )}
         </div>
       )}
       {step === "password" && (


### PR DESCRIPTION
## Summary
- embed build timestamp when running Vite build
- surface build age on picker page
- bump version to 1.0.52 and regenerate docs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4a87d1b148325b80fba083ac06034