### PR TITLE
feat: add raw json editor

### DIFF
--- a/docs/assets/index-D4hxquvg.css
+++ b/docs/assets/index-D4hxquvg.css
@@ -650,6 +650,9 @@ video {
 .flex-1 {
   flex: 1 1 0%;
 }
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
 .cursor-pointer {
   cursor: pointer;
 }
@@ -796,6 +799,10 @@ video {
 .bg-transparent {
   background-color: transparent;
 }
+.bg-zinc-700 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
 .bg-zinc-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(39 39 42 / var(--tw-bg-opacity, 1));
@@ -862,6 +869,9 @@ video {
 .text-right {
   text-align: right;
 }
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -915,6 +925,10 @@ video {
 .text-red-400 {
   --tw-text-opacity: 1;
   color: rgb(248 113 113 / var(--tw-text-opacity, 1));
+}
+.text-red-500 {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity, 1));
 }
 .text-transparent {
   color: transparent;

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-DCZOQWfT.js"></script>
+    <script type="module" crossorigin src="./assets/index-D2MbQu0z.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
-    <link rel="stylesheet" crossorigin href="./assets/index-BIMp42zr.css">
+    <link rel="stylesheet" crossorigin href="./assets/index-D4hxquvg.css">
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/src/components/ConfigPage.jsx
+++ b/src/components/ConfigPage.jsx
@@ -12,6 +12,7 @@ export default function ConfigPage({
   setAllocation,
   assets,
   liabilities,
+  onEditJson,
 }) {
   return (
     <div className="space-y-6">
@@ -27,6 +28,15 @@ export default function ConfigPage({
           setLiabilityTypes={setLiabilityTypes}
           liabilities={liabilities}
         />
+      </Section>
+      <Section title="Data">
+        <button
+          onClick={onEditJson}
+          className="h-8 px-3 rounded-lg bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+          title="Edit JSON"
+        >
+          Edit JSON
+        </button>
       </Section>
     </div>
   );

--- a/src/components/JsonEditorModal.jsx
+++ b/src/components/JsonEditorModal.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+export default function JsonEditorModal({ open, onClose, data, onSave }) {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setText(JSON.stringify(data, null, 2));
+    }
+  }, [open, data]);
+
+  let valid = true;
+  try {
+    JSON.parse(text);
+  } catch {
+    valid = false;
+  }
+
+  function handleSave() {
+    if (!valid) return;
+    const parsed = JSON.parse(text);
+    onSave(parsed);
+    onClose();
+  }
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+      <div className="bg-zinc-900 rounded-xl p-4 w-full max-w-3xl space-y-3">
+        <h2 className="text-lg font-medium">Edit JSON</h2>
+        <textarea
+          className="w-full h-64 rounded-lg bg-zinc-900 border border-zinc-800 px-3 py-2 text-zinc-100 font-mono text-sm"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        {!valid && <div className="text-red-500 text-sm">Invalid JSON</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close"
+            className="px-3 py-2 rounded-lg bg-zinc-800 border border-zinc-700 hover:bg-zinc-700"
+          >
+            ✖
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            title="Save"
+            disabled={!valid}
+            className={`px-3 py-2 rounded-lg ${valid ? "bg-blue-600 hover:bg-blue-500" : "bg-zinc-700 text-zinc-400 cursor-not-allowed"}`}
+          >
+            💾
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add modal for viewing and editing portfolio JSON
- allow editing underlying JSON from configuration screen
- bump version to 1.0.54 and rebuild docs

## Testing
- `npm test` *(fails: Cannot set property navigator of #<Object> which has only a getter)*
- `VITE_GOOGLE_API_KEY=dummy VITE_GOOGLE_CLIENT_ID=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4e384848325aeb3aaced45ffa0e