### PR TITLE
fix: close config when editing JSON

### DIFF
--- a/docs/assets/index-Dk562kzR.js
+++ b/docs/assets/index-Dk562kzR.js
@@ -2319,7 +2319,7 @@ function useLiabilityManager({ assets, liabilities, liabilityTypes, setAssetsAnd
     cancelDeleteLiability
   };
 }
-const version = "1.0.54";
+const version = "1.0.55";
 const pkg = {
   version
 };
@@ -2338,11 +2338,11 @@ function App() {
   const [editLiability, setEditLiability] = reactExports.useState(null);
   const [showTarget, setShowTarget] = reactExports.useState(false);
   const [jsonOpen, setJsonOpen] = reactExports.useState(false);
-  const driveApiKey = "dummy";
-  const driveClientId = "dummy";
+  const driveApiKey = "AIzaSyD9IhFBHBHEs729edMO7LsoKZFlTfsnv5U";
+  const driveClientId = "967365398072-sj6mjo1r3pdg18frmdl5aoafnvbbsfob.apps.googleusercontent.com";
   const driveReady2 = driveClientId;
   const builtAgo = reactExports.useMemo(() => {
-    const ts = "2025-08-19T19:52:25.562Z";
+    const ts = "2025-08-19T20:06:01.373Z";
     const diff = Date.now() - new Date(ts).getTime();
     const rtf = new Intl.RelativeTimeFormat(void 0, { numeric: "auto" });
     const seconds = Math.floor(diff / 1e3);
@@ -2745,7 +2745,10 @@ function App() {
           setAllocation,
           assets,
           liabilities,
-          onEditJson: () => setJsonOpen(true)
+          onEditJson: () => {
+            setConfigOpen(false);
+            setJsonOpen(true);
+          }
         }
       )
     ] }) })

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-D2MbQu0z.js"></script>
+    <script type="module" crossorigin src="./assets/index-Dk562kzR.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-D4hxquvg.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -434,7 +434,10 @@ export default function App() {
               setAllocation={setAllocation}
               assets={assets}
               liabilities={liabilities}
-              onEditJson={() => setJsonOpen(true)}
+              onEditJson={() => {
+                setConfigOpen(false);
+                setJsonOpen(true);
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- close config modal before showing JSON editor so editor is visible
- bump version to 1.0.55 and rebuild docs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d8b167f88325b5f7e561a5da9869