### PR TITLE
fix: show full cash in rebalance table

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio Tracker</title>
-    <script type="module" crossorigin src="./assets/index-Dk562kzR.js"></script>
+    <script type="module" crossorigin src="./assets/index-JrAvsM8G.js"></script>
     <link rel="modulepreload" crossorigin href="./assets/vendor-B1sYnIZH.js">
     <link rel="stylesheet" crossorigin href="./assets/index-D4hxquvg.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test2",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "description": "",
   "scripts": {
     "dev": "vite",

--- a/src/components/RebalancePlan.jsx
+++ b/src/components/RebalancePlan.jsx
@@ -13,7 +13,11 @@ function getSortValue(category, key, data) {
   const totalPriorityDebt = (priorityDebt || 0) + (priorityPayoff || 0);
   switch (key) {
     case "current":
-      return category === "priority_debt" ? -totalPriorityDebt : byCat[category] || 0;
+      return category === "priority_debt"
+        ? -totalPriorityDebt
+        : category === "cash"
+        ? data.cashCurrent || 0
+        : byCat[category] || 0;
     case "after":
       return category === "priority_debt"
         ? priorityDebt
@@ -102,6 +106,8 @@ export default function RebalancePlan({ data, assetTypes }) {
                   formatCurrency(
                     c === "priority_debt"
                       ? -totalPriorityDebt
+                      : c === "cash"
+                      ? data.cashCurrent || 0
                       : data.byCat[c] || 0
                   )
                 }

--- a/src/data.js
+++ b/src/data.js
@@ -64,6 +64,12 @@ export function rebalance(assets, liabilities, allocPct) {
   }
 
   const priorityPayoff = initialCash - cashAvailable;
+  const priorityDebt = adjLiabilities
+    .filter((l) => l.priority)
+    .reduce((sum, l) => sum + (Number(l.value) || 0), 0);
+  const nonPriorityLiabilities = adjLiabilities.filter((l) => !l.priority);
+  const byCatPrePayoff = currentByCategory(adjAssets, nonPriorityLiabilities);
+
   let toDeduct = priorityPayoff;
   for (const a of adjAssets) {
     if (a.type !== "cash" || toDeduct <= 0) continue;
@@ -72,11 +78,6 @@ export function rebalance(assets, liabilities, allocPct) {
     a.value = avail - used;
     toDeduct -= used;
   }
-
-  const priorityDebt = adjLiabilities
-    .filter((l) => l.priority)
-    .reduce((sum, l) => sum + (Number(l.value) || 0), 0);
-  const nonPriorityLiabilities = adjLiabilities.filter((l) => !l.priority);
 
   const totalNow = netWorth(adjAssets, adjLiabilities);
   const byCat = currentByCategory(adjAssets, nonPriorityLiabilities);
@@ -119,6 +120,7 @@ export function rebalance(assets, liabilities, allocPct) {
     investPlan,
     priorityDebt,
     priorityPayoff,
+    cashCurrent: byCatPrePayoff.cash || 0,
   };
 }
 

--- a/src/data.test.js
+++ b/src/data.test.js
@@ -44,3 +44,17 @@ test('rebalance byCat excludes priority debt from totals', () => {
   const sumByCat = Object.values(byCat).reduce((a, b) => a + b, 0);
   assert.equal(Math.round(sumByCat - priorityDebt), Math.round(totalNow));
 });
+
+test('rebalance cashCurrent excludes priority payoff', () => {
+  const assets = [
+    { type: 'cash', value: 100 },
+    { type: 'stock', value: 100 },
+  ];
+  const liabilities = [
+    { type: 'loan', value: 80, priority: true },
+    { type: 'loan', value: 20 },
+  ];
+  const { cashCurrent, byCat } = rebalance(assets, liabilities, {});
+  assert.equal(Math.round(cashCurrent), 90);
+  assert.equal(Math.round(byCat.cash), 17);
+});


### PR DESCRIPTION
## Summary
- show total cash in rebalance table without subtracting priority payoff
- test cash calculation from rebalance
- bump version to 1.0.56

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7492cc48325b600e3102536e1c1